### PR TITLE
Fix invalid CSS for responsive hero height

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -7,10 +7,10 @@ const Hero = styled.section`
   overflow: hidden;
   margin-bottom: ${props => (props.single ? '4rem' : '6rem')};
   @media (max-width: ${props => props.theme.breakpoints.m}), (max-device-width: ${props => props.theme.breakpoints.m}) {
-    ${props => (props.single ? '40vw' : '60vw')};
+    height: ${props => (props.single ? '40vw' : '60vw')};
   }
   @media (max-width: ${props => props.theme.breakpoints.s}), (max-device-width: ${props => props.theme.breakpoints.s}) {
-    ${props => (props.single ? '300px' : '400px')};
+    height: ${props => (props.single ? '300px' : '400px')};
   }
   @media (max-width: ${props => props.theme.breakpoints.xs}),
     (max-device-width: ${props => props.theme.breakpoints.xs}) {


### PR DESCRIPTION
The CSS for the hero height was invalid on the mobile screen width.